### PR TITLE
updated SWF SDK version that supports 'AmazonSimpleWorkflowClientBuilder'

### DIFF
--- a/doc_source/snippets/helloswf/pom.xml
+++ b/doc_source/snippets/helloswf/pom.xml
@@ -11,7 +11,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-simpleworkflow</artifactId>
-      <version>1.10.56</version>
+      <version>1.11.78</version>
     </dependency>
   </dependencies>
   <build>

--- a/doc_source/swf-basics.rst
+++ b/doc_source/swf-basics.rst
@@ -21,7 +21,7 @@ Dependencies
 Basic |SWF| applications will require the following dependencies, which are included with the
 |sdk-java|:
 
-* aws-java-sdk-1.10.*.jar
+* aws-java-sdk-1.11.*.jar
 * commons-logging-1.1.*.jar
 * httpclient-4.3.*.jar
 * httpcore-4.3.*.jar

--- a/doc_source/swf-hello.rst
+++ b/doc_source/swf-hello.rst
@@ -57,7 +57,7 @@ Development environment
 
 The development environment used in this tutorial consists of:
 
-* The |sdk-java|_ (v. 1.10.56 at the time of writing).
+* The |sdk-java|_ (v. 1.11.78 at the time of writing).
 * `Apache Maven <http://maven.apache.org/>`_ (3.3.1).
 * JDK 1.7 or later. This tutorial was developed and tested using JDK 1.8.0.
 * A good Java text editor (your choice).


### PR DESCRIPTION
The helloswf/pom.xml file specifies version 1.10.56 of the aws-java-sdk-simpleworkflow library however `com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflowClientBuilder` only exists in version 1.11.16 or later. Updated to the current version of the SDK (1.11.78) and tested.