### PR TITLE
Fixed issues with create-security-group sample code.

### DIFF
--- a/doc_source/create-security-group.rst
+++ b/doc_source/create-security-group.rst
@@ -52,7 +52,7 @@ EC2 Security Groups <using-network-security>` in the |EC2-ug|.
        .. code-block:: java
 
           CreateSecurityGroupResult createSecurityGroupResult =
-              amazonEC2Client.createSecurityGroup(createSecurityGroupRequest);
+              amazonEC2Client.createSecurityGroup(csgr);
 
        If you attempt to create a security group with the same name as an existing security group,
        :code:`createSecurityGroup` throws an exception.
@@ -80,7 +80,10 @@ ports.
           IpPermission ipPermission =
               new IpPermission();
 
-          ipPermission.withIpRanges("111.111.111.111/32", "150.150.150.150/32")
+          IpRange ipRange1 = new IpRange().withCidrIp("111.111.111.111/32");
+          IpRange ipRange2 = new IpRange().withCidrIp("150.150.150.150/32");
+
+          ipPermission.withIpv4Ranges(Arrays.asList(new IpRange[] {ipRange1, ipRange2}))
                       .withIpProtocol("tcp")
                       .withFromPort(22)
                       .withToPort(22);


### PR DESCRIPTION
Two fixes to create-security-group sample code (http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/create-security-group.html):

1. In the first code snippet, the object is created with the name "csgr":
`CreateSecurityGroupRequest csgr = new CreateSecurityGroupRequest();`
But in the next code snippet, object with incorrect name "createSecurityGroupRequest" was used instead of "csgr":
`CreateSecurityGroupResult createSecurityGroupResult =
    amazonEC2Client.createSecurityGroup(createSecurityGroupRequest);`

2. The documentation explicitly calls out the use of the `withIpv4Ranges` method however the code snippet uses the deprecated `withIpRanges` method.