### PR TITLE
Avoid truncating example text

### DIFF
--- a/doc_source/swf-hello.rst
+++ b/doc_source/swf-hello.rst
@@ -143,14 +143,14 @@ Create a SWF project
    .. literalinclude:: example_code/swf/pom.xml
        :language: xml
        :lines: 10-16
-       :dedent: 4
+       :dedent: 2
 
 #. *Make sure that Maven builds your project with JDK 1.7+ support*. Add the following to your
    project (either before or after the :code-xml:`<dependencies>` block) in :file:`pom.xml`:
 
    .. literalinclude:: example_code/swf/pom.xml
        :language: xml
-       :lines: 17-27
+       :lines: 17-28
        :dedent: 2
 
 Code the project


### PR DESCRIPTION
Under [Create a SWF project](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/swf-hello.html) on bullets 2 and 3, examples are truncated.  This is to fix that.