### PR TITLE
AWSSecurityTokenServiceClientBuilder should use static constructor

### DIFF
--- a/doc_source/prog-services-sts.adoc
+++ b/doc_source/prog-services-sts.adoc
@@ -52,7 +52,7 @@ For more information about activating STS regions and for a list of the availabl
 +
 [source,java]
 ----
-AWSSecurityTokenService sts_client = new AWSSecurityTokenServiceClientBuilder().standard().withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration("sts-endpoint.amazonaws.com", "signing-region")).build()
+AWSSecurityTokenService sts_client = AWSSecurityTokenServiceClientBuilder.standard().withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration("sts-endpoint.amazonaws.com", "signing-region")).build()
 ----
 +
 When creating the client with no arguments (``AWSSecurityTokenService sts_client = new AWSSecurityTokenServiceClientBuilder().standard().build();``), the default credential provider chain is used to retrieve credentials. You can provide a specific credential provider if you want. For more information, see <<credentials,Providing {AWS} Credentials in the {sdk-java}>>.


### PR DESCRIPTION
*Issue #, if available:*
Came across the issue myself.

*Description of changes:*
new AWSSecurityTokenServiceClientBuilder() is not possible as the constructor is private. AWSSecurityTokenServiceClientBuilder.standard() can be accessed directly to get an instance with the defaults as it is a static method. This is a bug fix in the documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
