### PR TITLE
CryptoRangeGetMode.ALL

### DIFF
--- a/doc_source/s3-encryption-migration.md
+++ b/doc_source/s3-encryption-migration.md
@@ -173,5 +173,5 @@ CryptoConfigurationV2 cryptoConfiguration = new CryptoConfigurationV2()
 // Allows range gets using AES/CTR and AES/CBC, for V1 and V2 objects
 CryptoConfigurationV2 cryptoConfiguration = new CryptoConfigurationV2()
        .withCryptoMode(CryptoMode.AuthenticatedEncryption)
-       .withRangeGetMode(CryptoRangeGetMode.ALL);
+       .withRangeGetMode(CryptoRangeGetMode.ALL); Is this relevant as CryptoRangeGetMode.ALL is deprecated?
 ```


### PR DESCRIPTION
CryptoRangeGetMode.ALL shows it is deprecated. What is the reason behind it and what is alternative to perform multipart downloads using Amazon S3 TransferManager?

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
